### PR TITLE
Review: WebView tests and Command Line Arguments [fixes #4]

### DIFF
--- a/lib/thrust.js
+++ b/lib/thrust.js
@@ -75,27 +75,33 @@ var thrust = function(spec, my) {
   // This method can be called multiple times to spawn different instances.
   // ```
   // @cb_       {function(err, api)}
+  // @options   {object} `exec_path`: The path to the thrust exec to use
+  //                      `args`    : dictionary of command line arguments
   // @exec_path {string} the executable to use
   // ```
-  spawn = function(cb_, exec_path) {
+  spawn = function(cb_, options) {
+    options = options || {};
     if(!my.THRUST_EXEC[os.platform()]) {
       return cb_(common.err('Platform not supported: ' + os.platform(),
                             'thrust:platform_not_supported'));
     }
 
-    if(os.platform() === 'win32') {
-      my.thrust_sock = '\\\\.\\pipe\\thrust.' + uid() + '.sock';
-    } 
-    else {
-      my.thrust_sock = path.join(os.tmpdir(),
-                                 'thrust.' + uid() + '.sock');
-    }
-
-    exec_path = exec_path || my.THRUST_EXEC[os.platform()];
+    var exec_path = options.exec_path || my.THRUST_EXEC[os.platform()];
     common.log.out('SPAWING ' + exec_path);
 
-    var p = require('child_process').spawn(exec_path,
-                                           ['--socket-path=' + my.thrust_sock]);
+    options.args = options.args || {};
+    var args = Object.keys(options.args).filter(function(arg) {
+      return !!options.args[arg];
+    }).map(function(arg) {
+      if(typeof options.args[arg] !== 'string') {
+        return '--' + arg;
+      }
+      else {
+        return '--' + arg + '=' + options.args[arg];
+      }
+    });
+    
+    var p = require('child_process').spawn(exec_path, args);
     p.stderr.on('data', function(c) {
       require('util').print(c.toString());
     });

--- a/test/base.js
+++ b/test/base.js
@@ -17,5 +17,8 @@
 
 module.exports = function(cb_) {
   var argv = require('minimist')(process.argv.slice(2));
-  require('../index.js')(cb_, argv.thrust_path || null);
+  require('../index.js')(cb_, { 
+    exec_path: argv.thrust_path || null,
+    args: {}
+  });
 };

--- a/test/webview_base.html
+++ b/test/webview_base.html
@@ -29,7 +29,7 @@
             console.log('NEW-WINDOW');
           });
           $('#test1 webview').on('console', function(evt) {
-            console.log('CONSOLE');
+            console.log('CONSOLE: ' + evt.originalEvent.message);
           });
         }, 1000);
       });

--- a/test/webview_dialog.html
+++ b/test/webview_dialog.html
@@ -1,0 +1,27 @@
+<html>
+  <body style="border: 1px solid black;">
+    <div style="border: 1px solid blue; height: 100%;" id="test">
+      <webview src="http://www.google.com"></webview>
+    </div>
+    <script src="http://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+    <script>
+      $(document).ready(function(){
+        setTimeout(function() {
+          //$('#test1 webview').remove();
+          console.log('ProcessId: ' + $('#test webview')[0].getProcessId());
+
+          $('#test webview')[0].openDevTools();
+          $('#test webview')[0].executeScript('console.log("CONFIRM: " + window.confirm("OK!")); console.log("test");');
+
+          $('#test webview').on('dialog', function(evt) {
+            console.log('DIALOG: ' + evt.originalEvent.message_type);
+            evt.originalEvent.ok('test');
+          });
+          $('#test webview').on('console', function(evt) {
+            console.log('CONSOLE: ' + evt.originalEvent.message);
+          });
+        }, 1000);
+      });
+    </script>
+  </body>
+</html>

--- a/test/webview_dialog.js
+++ b/test/webview_dialog.js
@@ -1,0 +1,33 @@
+var async = require('async');
+var common = require('../lib/common.js');
+
+var _api = null;
+var _window = null;
+
+async.series([
+  function(cb_) {
+    require('./base.js')(function(err, api) {
+      _api = api;
+      return cb_(err);
+    });
+  },
+  function(cb_) {
+    _window = _api.window({
+      size: {
+        width: 1024,
+        height: 768
+      },
+      root_url: 'file://' + require('path').resolve(__dirname, 'webview_dialog.html')
+    });
+    return cb_();
+  },
+  function(cb_) {
+    _window.show(cb_);
+  }
+], function(err) {
+  if(err) {
+    common.log.out('FAILED');
+    common.log.error(err);
+  }
+  common.log.out('OK');
+});


### PR DESCRIPTION
This adds an options object as second argument to the main function that can take an `args` dictionary and a custom `exec_path` string.

```
// test.js
require('node-thrust')(function(err, api) {
  // ...
}), {
  args: {
    "show-fps-counter": true
  },
  exec_path: '...'
});
```
